### PR TITLE
change publish path

### DIFF
--- a/modules/assemble_taxa.nf
+++ b/modules/assemble_taxa.nf
@@ -23,7 +23,7 @@ process assemble_flye {
     conda "bioconda::flye=2.9"
     container "biocontainers/flye:2.9--py39h6935b12_1"
 
-    publishDir path: "${params.outdir}/${unique_id}/assemblies/${taxon}", mode: 'copy', pattern: "flye/assembly.fasta", saveAs: {filename -> "flye_assembled_contigs.fa"}
+    publishDir "${params.outdir}/${unique_id}/assemblies/${taxon}", mode: 'copy', pattern: "flye/assembly.fasta", saveAs: {filename -> "flye_assembled_contigs.fa"}
     input:
         tuple val(unique_id), val(taxon), path(fastq)
     output:
@@ -41,7 +41,7 @@ process assemble_rnabloom {
     conda "bioconda::rnabloom"
     container "docker.io/jdelling7igfl/rnabloom:2.0.1"
 
-    publishDir path: "${params.outdir}/${unique_id}/assemblies/${taxon}", mode: 'copy', pattern: "rnabloom/rnabloom.transcripts.fa", saveAs: {filename -> "rnabloom_assembled_contigs.fa"}
+    publishDir "${params.outdir}/${unique_id}/assemblies/${taxon}", mode: 'copy', pattern: "rnabloom/rnabloom.transcripts.fa", saveAs: {filename -> "rnabloom_assembled_contigs.fa"}
     input:
         tuple val(unique_id), val(taxon), path(fastq)
     output:
@@ -59,7 +59,7 @@ process assemble_megahit {
 	conda "bioconda::megahit conda-forge::bzip2 conda-forge::libcxx=8.0"
 	container "biocontainers/mulled-v2-0f92c152b180c7cd39d9b0e6822f8c89ccb59c99:8ec213d21e5d03f9db54898a2baeaf8ec729b447-0"
 
-    publishDir path: "${params.outdir}/${unique_id}/assemblies/${taxon}", mode: 'copy', pattern: "megahit/final.contigs.fa", saveAs: {filename -> "megahit_assembled_contigs.fa"}
+    publishDir "${params.outdir}/${unique_id}/assemblies/${taxon}", mode: 'copy', pattern: "megahit/final.contigs.fa", saveAs: {filename -> "megahit_assembled_contigs.fa"}
     input:
         tuple val(unique_id), val(taxon), path(fastq)
     output:
@@ -78,7 +78,7 @@ process assemble_rnaspades {
     conda "bioconda::spades=3.15 conda-forge::pyyaml==3.12"
     container "biocontainers/spades:3.15.5--h95f258a_1"
 
-    publishDir path: "${params.outdir}/${unique_id}/assemblies/${taxon}", mode: 'copy', pattern: "rnaspades/soft_filtered_transcripts.fasta", saveAs: {filename -> "rnaspades_assembled_contigs.fa"}
+    publishDir "${params.outdir}/${unique_id}/assemblies/${taxon}", mode: 'copy', pattern: "rnaspades/soft_filtered_transcripts.fasta", saveAs: {filename -> "rnaspades_assembled_contigs.fa"}
 
     input:
         tuple val(unique_id), val(taxon), path(fastq)
@@ -97,7 +97,7 @@ process assemble_megahit_paired {
     conda "bioconda::megahit conda-forge::bzip2 conda-forge::libcxx=8.0"
 	container "biocontainers/mulled-v2-0f92c152b180c7cd39d9b0e6822f8c89ccb59c99:8ec213d21e5d03f9db54898a2baeaf8ec729b447-0"
 
-    publishDir path: "${params.outdir}/${unique_id}/assemblies/${taxon}", mode: 'copy', pattern: "megahit/final.contigs.fa", saveAs: {filename -> "megahit_assembled_contigs.fa"}
+    publishDir "${params.outdir}/${unique_id}/assemblies/${taxon}", mode: 'copy', pattern: "megahit/final.contigs.fa", saveAs: {filename -> "megahit_assembled_contigs.fa"}
 
     input:
         tuple val(unique_id), val(taxon), path(fastq_1), path(fastq_2)
@@ -117,7 +117,7 @@ process assemble_rnaspades_paired {
     conda "bioconda::spades=3.15 conda-forge::pyyaml==3.12"
     container "biocontainers/spades:3.15.5--h95f258a_1"
 
-    publishDir path: "${params.outdir}/${unique_id}/assemblies/${taxon}", mode: 'copy', pattern: "rnaspades/soft_filtered_transcripts.fasta", saveAs: {filename -> "rnaspades_assembled_contigs.fa"}
+    publishDir "${params.outdir}/${unique_id}/assemblies/${taxon}", mode: 'copy', pattern: "rnaspades/soft_filtered_transcripts.fasta", saveAs: {filename -> "rnaspades_assembled_contigs.fa"}
 
     input:
         tuple val(unique_id), val(taxon), path(fastq_1), path(fastq_2)
@@ -136,7 +136,7 @@ process generate_assembly_stats {
     conda "bioconda::bbmap"
     container "biocontainers/bbmap:39.01--h92535d8_1"
 
-    publishDir path: "${params.outdir}/${unique_id}/assemblies/${taxon}", mode: 'copy', pattern: "assembly_stats.txt"
+    publishDir "${params.outdir}/${unique_id}/assemblies/${taxon}", mode: 'copy', pattern: "assembly_stats.txt"
     input:
         tuple val(unique_id), val(taxon), path(contigs)
     output:

--- a/modules/centrifuge_classification.nf
+++ b/modules/centrifuge_classification.nf
@@ -22,7 +22,7 @@ process centrifuge {
     label "process_higher_memory"
 
     container "docker.io/ontresearch/centrifuge:latest"
-    publishDir path: "${params.outdir}/${unique_id}/classifications", mode: 'copy'
+    publishDir "${params.outdir}/${unique_id}/classifications", mode: 'copy'
 
     input:
         tuple val(unique_id), path(fastq)
@@ -43,7 +43,7 @@ process centrifuge_report {
     label 'process_low'
 
     container "docker.io/ontresearch/centrifuge:latest"
-    publishDir path: "${params.outdir}/${unique_id}/classifications", mode: 'copy'
+    publishDir "${params.outdir}/${unique_id}/classifications", mode: 'copy'
 
     input:
         tuple val(unique_id), path(assignments)

--- a/modules/check_hcid_status.nf
+++ b/modules/check_hcid_status.nf
@@ -7,7 +7,7 @@ process check_hcid {
     conda "bioconda::mappy=2.26"
     container "biocontainers/mappy:2.26--py310h83093d7_1"
 
-    publishDir path: "${params.outdir}/${unique_id}/qc/", mode: 'copy'
+    publishDir "${params.outdir}/${unique_id}/qc/", mode: 'copy'
 
     input:
         tuple val(unique_id), path(kreport), path(reads)

--- a/modules/extract_all.nf
+++ b/modules/extract_all.nf
@@ -15,7 +15,7 @@ process split_kreport {
     conda "python=3.10"
     container "biocontainers/python:3.10"
 
-    publishDir path: "${params.outdir}/${unique_id}/classifications", mode: "copy", pattern: "*.json"
+    publishDir "${params.outdir}/${unique_id}/classifications", mode: "copy", pattern: "*.json"
 
     input:
         tuple val(unique_id), path(kreport)
@@ -289,7 +289,7 @@ process bgzip_extracted_taxa {
       
       label "process_medium"
   
-      publishDir path: "${params.outdir}/${unique_id}/${prefix}", mode: "copy"
+      publishDir "${params.outdir}/${unique_id}/${prefix}", mode: "copy"
   
       conda "bioconda::tabix=1.11"
       container "${params.wf.container}:${params.wf.container_version}"
@@ -313,7 +313,7 @@ process merge_read_summary {
 
     label "process_single"
 
-    publishDir path: "${params.outdir}/${unique_id}/${prefix}", pattern: "reads_summary_combined.json", mode: "copy"
+    publishDir "${params.outdir}/${unique_id}/${prefix}", pattern: "reads_summary_combined.json", mode: "copy"
 
     container "${params.wf.container}:${params.wf.container_version}"
 

--- a/modules/generate_report.nf
+++ b/modules/generate_report.nf
@@ -4,7 +4,7 @@ process make_report {
     label "process_single"
     label "process_high_memory"
 
-    publishDir path: "${params.outdir}/${unique_id}/", mode: 'copy'
+    publishDir "${params.outdir}/${unique_id}/", mode: 'copy'
     
     conda "anaconda::Mako=1.2.3"
     container "${params.wf.container}:${params.wf.container_version}"

--- a/modules/kraken_client.nf
+++ b/modules/kraken_client.nf
@@ -11,7 +11,7 @@ process kraken2_client {
     container "${params.wf.container}:${params.wf.container_version}"
     containerOptions {workflow.profile != "singularity" ? "--network host" : ""}
 
-    publishDir path: "${params.outdir}/${unique_id}/classifications", mode: "copy"
+    publishDir "${params.outdir}/${unique_id}/classifications", mode: "copy"
 
     input:
         tuple val(unique_id), path(fastq)
@@ -56,7 +56,7 @@ process bracken {
     
     label "process_low"
 
-    publishDir path: "${params.outdir}/${unique_id}/classifications", mode: "copy"
+    publishDir "${params.outdir}/${unique_id}/classifications", mode: "copy"
 
     conda "bioconda::bracken=2.7"
     container "biocontainers/bracken:2.9--py39h1f90b4d_0"
@@ -83,7 +83,7 @@ process bracken_to_json {
     
     label "process_low"
 
-    publishDir path: "${params.outdir}/${unique_id}/classifications", mode: "copy"
+    publishDir "${params.outdir}/${unique_id}/classifications", mode: "copy"
     
     conda "bioconda::taxonkit=0.15.1 python=3.10"
     container "${params.wf.container}:${params.wf.container_version}"
@@ -111,7 +111,7 @@ process kraken_to_json {
 
     label "process_low"
 
-    publishDir path: "${params.outdir}/${unique_id}/classifications", mode: "copy"
+    publishDir "${params.outdir}/${unique_id}/classifications", mode: "copy"
 
     conda "bioconda::taxonkit=0.15.1 python=3.10"
     container "${params.wf.container}:${params.wf.container_version}"

--- a/modules/sourmash_classification.nf
+++ b/modules/sourmash_classification.nf
@@ -79,7 +79,7 @@ process sourmash_tax_metagenome {
 
     conda "bioconda::sourmash=4.8.4"
     container "biocontainers/sourmash:4.8.4--hdfd78af_0"
-    publishDir path: "${params.outdir}/${unique_id}/classifications", mode: 'copy', pattern: '*.csv'
+    publishDir "${params.outdir}/${unique_id}/classifications", mode: 'copy', pattern: '*.csv'
 
     input:
         tuple val(unique_id), path(gather_csv)
@@ -103,7 +103,7 @@ process sourmash_to_json {
 
     label "process_low"
 
-    publishDir path: "${params.outdir}/${unique_id}/classifications", mode: 'copy'
+    publishDir "${params.outdir}/${unique_id}/classifications", mode: 'copy'
 
     conda "bioconda::biopython=1.78 anaconda::Mako=1.2.3"
     container "${params.wf.container}:${params.wf.container_version}"


### PR DESCRIPTION
Remove the word `path` from publishDir path
Either this does nothing (as it's documented to just be a short hand) or it fixes a problem seen locally.
In my case, the publish path is set in the config to a default value and overridden on the command line. In the qc module, I found that the files were published to the command line path, and everywhere else they seem to have been written to the default output directory specified in the config file.