### PR TITLE
Output HCID reads and change extraction level per domain

### DIFF
--- a/conf/params.config
+++ b/conf/params.config
@@ -102,21 +102,24 @@ params {
     spike_in_ref_dir = "${projectDir}/resources/spike_ins"
 
     kreport_splits = "Bacteria Viruses Metazoa"
-    extract_rank="S"
     extract_thresholds = [
         'Viruses': [
+            "taxon_rank": "F",
             "min_reads": 2,
             "min_percent": 0
         ],
         'Metazoa': [
+            "taxon_rank": "G",
             "min_reads": 100,
             "min_percent": 100
         ],
         'Bacteria': [
+            "taxon_rank": "S",
             "min_reads": 100,
             "min_percent": 1
         ],
         'default': [
+            "taxon_rank": "G",
             "min_reads": 100,
             "min_percent": 0.1
         ]

--- a/modules/check_hcid_status.nf
+++ b/modules/check_hcid_status.nf
@@ -4,8 +4,8 @@ process check_hcid {
 
     label "process_single"
 
-    conda "bioconda::mappy=2.26"
-    container "biocontainers/mappy:2.26--py310h83093d7_1"
+    conda "bioconda::mappy=2.28 bioconda::pyfastx=2.1.0"
+    container "community.wave.seqera.io/library/mappy_pyfastx:b4cc4b80f5e5decf"
 
     publishDir "${params.outdir}/${unique_id}/qc/", mode: 'copy'
 
@@ -16,6 +16,7 @@ process check_hcid {
         path hcid_refs
     output:
         tuple val(unique_id), path("*.warning.json"), emit: warnings, optional: true
+        tuple val(unique_id), path("*.reads.fq"), emit: reads, optional: true
         tuple val(unique_id), path("hcid.counts.csv"), emit: counts
     script:
         preset = ""

--- a/modules/extract_all.nf
+++ b/modules/extract_all.nf
@@ -43,7 +43,7 @@ process extract_taxa_paired_reads {
     container "biocontainers/pyfastx:2.0.1--py39h3d4b85c_0"
 
     input:
-        tuple val(unique_id), path(fastq1), path(fastq2), path(kraken_assignments), path(kreport), val(min_reads), val(min_percent)
+        tuple val(unique_id), path(fastq1), path(fastq2), path(kraken_assignments), path(kreport), val(taxon_rank), val(min_reads), val(min_percent)
         path taxonomy_dir
     output:
         tuple val(unique_id), path("*.fastq"), emit: reads
@@ -62,7 +62,7 @@ process extract_taxa_paired_reads {
             -p ${kreport} \
             --include_children \
             --min_count_descendants ${min_reads} \
-            --rank ${params.extract_rank} \
+            --rank ${taxon_rank} \
             --min_percent ${min_percent} \
             ${extra}
 

--- a/modules/extract_all.nf
+++ b/modules/extract_all.nf
@@ -86,7 +86,7 @@ process extract_taxa_reads {
     container "biocontainers/pyfastx:2.0.1--py39h3d4b85c_0"
 
     input:
-        tuple val(unique_id), path(fastq), path(kraken_assignments), path(kreport), val(min_reads), val(min_percent)
+        tuple val(unique_id), path(fastq), path(kraken_assignments), path(kreport), val(taxon_rank), val(min_reads), val(min_percent)
         path taxonomy_dir
     output:
         tuple val(unique_id), path("*.f*q"), emit: reads
@@ -104,7 +104,7 @@ process extract_taxa_reads {
             -p ${kreport} \
             --include_children \
             --min_count_descendants ${min_reads} \
-            --rank ${params.extract_rank} \
+            --rank ${taxon_rank} \
             --min_percent ${min_percent} \
             ${extra}
 
@@ -356,7 +356,7 @@ workflow extract_taxa {
                 }
             .set { result }
         result.valid.concat(result.invalid)
-                    .map { unique_id, kreport, key -> [unique_id, kreport, thresholds.get(key,"false").get("min_reads","false"), thresholds.get(key,"false").get("min_percent","false")] }
+                    .map { unique_id, kreport, key -> [unique_id, kreport, thresholds.get(key,"false").get("taxon_rank","false"), thresholds.get(key,"false").get("min_reads","false"), thresholds.get(key,"false").get("min_percent","false")] }
                     .set{ kreport_params_ch }
 
         fastq_ch.combine(assignments_ch, by: 0)

--- a/modules/kraken_client.nf
+++ b/modules/kraken_client.nf
@@ -56,6 +56,8 @@ process bracken {
     
     label "process_low"
 
+    errorStrategy {"ignore"}
+
     publishDir "${params.outdir}/${unique_id}/classifications", mode: "copy"
 
     conda "bioconda::bracken=2.7"
@@ -148,14 +150,11 @@ workflow run_kraken_and_bracken {
         if (params.run_bracken) {
             bracken_length = determine_bracken_length(database)
             bracken(kraken2_client.out.report, database, bracken_length)
-            bracken_to_json(bracken.out.summary, taxonomy)
-            out_json = bracken_to_json.out
-            out_report = bracken.output.report
-        } else {
-            kraken_to_json(kraken2_client.out.report, taxonomy)
-            out_json = kraken_to_json.out
-            out_report = kraken2_client.out.report
+
         }
+        kraken_to_json(kraken2_client.out.report, taxonomy)
+        out_json = kraken_to_json.out
+        out_report = kraken2_client.out.report
     emit:
         assignments = kraken2_client.out.assignments
         kreport = out_report


### PR DESCRIPTION
- For HCIDs which trigger a warning, output a file of HCID reads
- Change `extract_taxa_paired_reads` and `extract_taxa_reads` to take per-domain `taxon_rank` as specified in the `params.config`
- Update to `run_bracken` to make it run and output the file without using it downstream