### PR TITLE
Viral reclassification #75

### DIFF
--- a/bin/assignment.py
+++ b/bin/assignment.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import sys
 from collections import defaultdict
 
@@ -17,34 +19,82 @@ def trim_read_id(read_id):
 
     return read_id
 
-
-def parse_kraken_assignment_line(line):
+class KrakenAssignmentEntry:
     """
-    Parses the read_id and taxon_id from a line in the kraken assignment file.
+    A class representing a line in a kraken assignment file.
 
-    Parameters:
-        line (str): A line from kraken assignment file.
-
-    Returns:
-        taxon_id (str): The NCBI taxon identifier.
-        read_id (str): trimmed read identifier.
+    Attributes:
+        classified (str): C if read classified, U if unclassified
+        read_id (str): The read name
+        taxon_id (str): The NCBI taxon identifier
+        length (int): Length of read in bp
+        kmer_string (str): space separated string representing the taxon_ids matched along the read
     """
-    line_vals = line.strip().split("\t")
-    if len(line_vals) < 5:
-        return -1, ""
-    if "taxid" in line_vals[2]:
-        temp = line_vals[2].split("taxid ")[-1]
-        taxon_id = temp[:-1]
-    else:
-        taxon_id = line_vals[2]
+    def __init__(self, line=None):
+        """
+        Initializes an KrakenAssignmentEntry object.
 
-    read_id = trim_read_id(line_vals[1])
+        Parameters:
+            row (str): A row from a kraken file
+        """
+        self.classified = "U"
+        self.read_id = ""
+        self.taxon_id = "0"
+        self.length = 0
+        self.kmer_string = ""
+        if line is not None:
+            self.add_line(line)
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        else:
+            return False
 
-    if taxon_id == "A":
-        taxon_id = "81077"
-    else:
-        taxon_id = taxon_id
-    return taxon_id, read_id
+    def add_line(self, line):
+        """
+        Parses the line in the kraken assignment file.
+
+        Parameters:
+            line (str): A line from kraken assignment file.
+
+        """
+        num_fields = len(line.split("\t"))
+        if num_fields != 5:
+            sys.stderr.write(
+                f"Kraken assignment line {line} badly formatted - must have 5 fields"
+            )
+            sys.exit(11)
+        self.classified, self.read_id, self.taxon_id, length, self.kmer_string = line.strip().split("\t")
+        self.length = int(length)
+
+        #if "taxid" in self.taxon_id:
+        #    temp = self.taxon_id.split("taxid ")[-1]
+        #    self.taxon_id = temp[:-1] // can't remember where this came from so leave it out
+
+        self.read_id = trim_read_id(self.read_id)
+
+        if self.taxon_id == "A":
+            self.taxon_id = "81077"
+
+    def declassify(self):
+        """
+            Changes the classified status of KrakenAssignmentEntry to unclassified
+        """
+        self.classified = "U"
+        self.taxon_id = "0"
+
+    def get_line(self):
+        """
+            Get string representation of KrakenAssignmentEntry
+        """
+        fields = [self.classified, self.read_id, self.taxon_id, str(self.length), self.kmer_string]
+        return "\t".join(fields)
+
+    def print(self):
+        """
+        Print the attributes of KrakenAssignmentEntry as a string
+        """
+        print(f"{self.get_line()}")
 
 
 class KrakenAssignments:
@@ -52,15 +102,26 @@ class KrakenAssignments:
     A class representing a kraken assignment file.
 
     Attributes:
-        file (str): Name of file to parse.
+        file_name (str): Name of file to parse.
+        load (bool): If set loads the contents of the file into memory
     """
-    def __init__(self, assignment_file):
+    def __init__(self, assignment_file, load=False):
         """
         Initializes an KrakenAssignments object.
         """
-        self.file = assignment_file
+        self.entries = defaultdict(KrakenAssignmentEntry)
+        self.file_name = assignment_file
 
-    def parse_kraken_assignment_file(self, taxon_id_map, parents=None):
+        if load:
+            self.load_file()
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        else:
+            return False
+
+    def get_read_map(self, taxon_id_map, parents=None):
         """
         Parses the kraken assignment file and collects the read_ids associated with each of the
         required taxon ids.
@@ -74,9 +135,10 @@ class KrakenAssignments:
                              read_id was classified as the taxon_id.
         """
         read_map = defaultdict(set)
-        with open(self.file, "r") as kfile:
+        with open(self.file_name, "r") as kfile:
             for line in kfile:
-                taxon_id, read_id = parse_kraken_assignment_line(line)
+                assignment = KrakenAssignmentEntry(line)
+                taxon_id, read_id = assignment.taxon_id, assignment.read_id
                 if taxon_id in taxon_id_map:
                     if read_id in read_map and taxon_id != read_map[read_id]:
                         del read_map[read_id]
@@ -94,4 +156,57 @@ class KrakenAssignments:
                             else:
                                 read_map[read_id].add(current)
         return read_map
+
+    def load_file(self, taxon_ids=None):
+        """
+        Loads all entries in the kraken assignment file. If this is a paired file and there is a clash, result is unclassified
+
+        Parameters:
+            taxon_ids (iterable): A subset of taxon_ids to retain assignment lines from.
+        """
+        with open(self.file_name, "r") as kfile:
+            for line in kfile:
+                assignment = KrakenAssignmentEntry(line)
+                if (taxon_ids and assignment.taxon_id in taxon_ids) or not taxon_ids:
+                    if assignment.read_id in self.entries and assignment.taxon_id != self.entries[assignment.read_id].taxon_id:
+                        self.entries[assignment.read_id].declassify()
+                    else:
+                        self.entries[assignment.read_id] = assignment
+
+    def update(self, new_assignments, changes=None):
+        """
+        Updates read assignments using new file with preference
+
+        Parameters:
+            new_assignments (KrakenAssignments): A new loaded KrakenAssignments object.
+        """
+        if not changes:
+            changes = defaultdict(lambda : defaultdict(int))
+
+        if len(self.entries) == 0:
+            self.entries = new_assignments.entries
+            return
+
+        for read_id, entry in new_assignments.entries.items():
+            if read_id not in self.entries:
+                self.entries[read_id] = entry
+                changes["0"][entry.taxon_id] += 1
+
+            elif (read_id in self.entries
+                  and entry.classified == "C"
+                  and entry.taxon_id != self.entries[read_id].taxon_id):
+                old_taxon_id = self.entries[read_id].taxon_id
+                new_taxon_id = entry.taxon_id
+                self.entries[read_id] = entry
+                changes[old_taxon_id][new_taxon_id] += 1
+
+        return changes
+
+    def save(self):
+        """
+            Save the KrakenAssignments object in kraken assignment format
+        """
+        with open(self.file_name, "w") as out:
+            for taxon_id, entry in self.entries.items():
+                out.write(f"{entry.get_line()}\n")
 

--- a/bin/extract_fraction_from_reads.py
+++ b/bin/extract_fraction_from_reads.py
@@ -122,7 +122,7 @@ def main():
 
     # Initialize kraken assignment file
     kraken_assignment = KrakenAssignments(args.kraken_assignment_file)
-    read_map = kraken_assignment.parse_kraken_assignment_file(taxon_id_map)
+    read_map = kraken_assignment.get_read_map(taxon_id_map)
 
     out_counts = extract_reads(
         read_map,

--- a/bin/extract_taxa_from_reads.py
+++ b/bin/extract_taxa_from_reads.py
@@ -109,7 +109,7 @@ def extract_taxa(
         #    "INCLUDING PARENTS/CHILDREN, HAVE %i TAXA TO INCLUDE IN READ FILES for %s\n"
         #    % (len(lists_to_extract[taxon]), taxon)
         # )
-    read_map = kraken_assignment.parse_kraken_assignment_file(subtaxa_map)
+    read_map = kraken_assignment.get_read_map(subtaxa_map)
 
     prefixes = setup_prefixes(lists_to_extract, prefix)
     out_counts, quals, lens, filenames = process_read_files(

--- a/bin/extract_taxa_from_reads.py
+++ b/bin/extract_taxa_from_reads.py
@@ -275,7 +275,8 @@ def main():
     # Load kraken report entries
     sys.stderr.write("Loading kraken report\n")
     kraken_report = KrakenReport(args.report_file)
-    kraken_report.check_host({9606:args.max_human})
+    if args.max_human:
+        kraken_report.check_host({"9606":args.max_human})
 
     # Initialize kraken assignment file
     sys.stderr.write("Loading kraken assignments\n")

--- a/bin/extract_taxa_from_reads.py
+++ b/bin/extract_taxa_from_reads.py
@@ -48,7 +48,7 @@ def get_taxon_id_lists(
             continue
         if min_count_descendants and entry.count < min_count_descendants:
             continue
-        if min_percent and kraken_report.get_percentage(taxon) < min_percent:
+        if min_percent and kraken_report.get_percentage(taxon, denominator="classified") < min_percent:
             continue
         if len(names) > 0 and entry.name not in names and taxon not in names:
             continue
@@ -215,7 +215,7 @@ def main():
         dest="min_percent",
         required=False,
         type=float,
-        help="Minimum percentage of reads e.g 4",
+        help="Minimum percentage of classified reads e.g 4",
     )
     parser.add_argument(
         "--n",

--- a/bin/extract_taxa_from_reads.py
+++ b/bin/extract_taxa_from_reads.py
@@ -34,6 +34,11 @@ def get_taxon_id_lists(
     include_parents=False,
     include_children=False
 ):
+    """
+    Loops through the kraken report, and for each taxon_id in the report, if it meets the thresholds, a key is added to
+    lists_to_extract. The values in this dictionary are all taxon_ids which should be added to the file alongside the
+    key taxon_id (e.g. parents or children)
+    """
     lists_to_extract = defaultdict(set)
     for taxon in kraken_report.entries:
         entry = kraken_report.entries[taxon]
@@ -100,8 +105,8 @@ def extract_taxa(
     # open read files
     filetype, zipped = check_read_files(reads1)
 
+    # This inverts the lists_to_extract to identify for an assigned taxon_id, which taxon_id files it should be added to.
     subtaxa_map = defaultdict(set)
-
     for taxon, subtaxons in lists_to_extract.items():
         for subtaxa in subtaxons:
             subtaxa_map[subtaxa].add(taxon)

--- a/bin/extract_utils.py
+++ b/bin/extract_utils.py
@@ -229,7 +229,8 @@ def file_iterator(read_file, read_map, subtaxa_map, inverse, out_counts, quals, 
         trimmed_name = trim_read_id(name)
         if inverse:
             if trimmed_name in reads_of_interest:
-                for taxon in read_map[trimmed_name]:
+                taxon_id = read_map[trimmed_name]
+                for taxon in subtaxa_map[taxon_id]:
                     update_summary_with_record(taxon, record, out_counts, quals, lens)
                 continue
             else:
@@ -239,10 +240,10 @@ def file_iterator(read_file, read_map, subtaxa_map, inverse, out_counts, quals, 
         elif not inverse:
             if trimmed_name not in reads_of_interest:
                 continue
-            for k2_taxon in read_map[trimmed_name]:
-                for taxon in subtaxa_map[k2_taxon]:
-                    count += 1
-                    add_record(taxon, record, out_counts, quals, lens, filenames, file_index, out_handles=out_handles, out_records=out_records)
+            taxon_id = read_map[trimmed_name]
+            for taxon in subtaxa_map[taxon_id]:
+                count += 1
+                add_record(taxon, record, out_counts, quals, lens, filenames, file_index, out_handles=out_handles, out_records=out_records)
 
     if not low_memory:
         save_records_to_file(out_records, filenames, file_index)

--- a/bin/merge.py
+++ b/bin/merge.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+
+from collections import defaultdict
+import sys
+import argparse
+from datetime import datetime
+
+
+from report import KrakenReport
+from assignment import KrakenAssignments
+
+def merge_all_assignments(list_assignment_files, output_file):
+    kraken_assignments = KrakenAssignments(output_file)
+    changes = defaultdict(lambda: defaultdict(int))
+
+    for assignment_file in list_assignment_files:
+        changes = kraken_assignments.update(assignment_file, changes)
+
+    kraken_assignments.save()
+    return changes
+
+def check_pair(kraken_assignment_file, kraken_report_file):
+    report_stem = kraken_report_file.split("/")[-1].split("kraken")[0]
+    assignment_stem = kraken_assignment_file.split("/")[-1].split("kraken")[0]
+    if report_stem != assignment_stem:
+        print(f"Found report stem {report_stem} and assignment stem {assignment_stem} from files {kraken_report_file} and {kraken_assignment_file}")
+    assert(report_stem == assignment_stem)
+
+    kreport = KrakenReport(kraken_report_file)
+    kassignments = KrakenAssignments(kraken_assignment_file, load=True)
+
+    counts = defaultdict(int)
+    for read_id,entry in kassignments.entries.items():
+        counts[entry.taxon_id] += 1
+    #print(counts)
+
+    for taxon_id in kreport.entries:
+        if counts[taxon_id] != kreport.entries[taxon_id].ucount:
+            print(f"A: Taxon id {taxon_id} has {kreport.entries[taxon_id].ucount} counts in report and {counts[taxon_id]} counts in assignment file")
+
+        if taxon_id in counts:
+            del counts[taxon_id]
+    for taxon_id in counts:
+        print(
+            f"B: Taxon id {taxon_id} has {kreport.entries[taxon_id].ucount} counts in report and {counts[taxon_id]} counts in assignment file")
+
+    return kassignments, kreport
+
+def merge(kraken_assignment_files, kraken_report_files, out_prefix):
+    print("Initialize merged KrakenAssignments and KrakenReport")
+    merged_assignments = KrakenAssignments(f"{out_prefix}.kraken_assignments.tsv")
+    merged_reports = KrakenReport()
+
+    assert(len(kraken_assignment_files) == len(kraken_report_files))
+
+    pairs = zip(kraken_assignment_files, kraken_report_files)
+    for assignment_file, report_file in pairs:
+        print(f"Update with pair {assignment_file} and {report_file}")
+        new_assignments, new_report = check_pair(assignment_file, report_file)
+
+        changes = merged_assignments.update(new_assignments)
+        merged_reports.update(new_report, changes)
+        merged_assignments.save()
+        merged_reports.save(f"{out_prefix}.kraken_report.txt")
+
+    print(f"Save results to {out_prefix}.kraken_assignments.tsv and {out_prefix}.kraken_report.txt")
+    merged_assignments.save()
+    merged_reports.save(f"{out_prefix}.kraken_report.txt")
+
+# Main method
+def main():
+    # Parse arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-r",
+        dest="in_reports",
+        nargs ='+',
+        required=True,
+        help='A number of kraken reports for the same dataset ordered by preference (later=higher)'
+    )
+    parser.add_argument(
+            "-a",
+            dest="in_assignments",
+            nargs ='+',
+            required=True,
+            help='A number of kraken assignment files for the same dataset ordered by preference (later=higher)'
+        )
+
+    args = parser.parse_args()
+
+    # Start Program
+    now = datetime.now()
+    time = now.strftime("%m/%d/%Y, %H:%M:%S")
+    sys.stdout.write("PROGRAM START TIME: " + time + "\n")
+
+    merge(args.in_assignments, args.in_reports, "merged")
+
+    now = datetime.now()
+    time = now.strftime("%m/%d/%Y, %H:%M:%S")
+    sys.stdout.write("PROGRAM END TIME: " + time + "\n")
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/merge.py
+++ b/bin/merge.py
@@ -2,9 +2,11 @@
 
 from collections import defaultdict
 import sys
+import argparse
+from datetime import datetime
 
-from krakenpy.report import KrakenReport
-from krakenpy.assignment import KrakenAssignments
+from report import KrakenReport
+from assignment import KrakenAssignments
 
 def merge_all_assignments(list_assignment_files, output_file):
     kraken_assignments = KrakenAssignments(output_file)
@@ -65,3 +67,41 @@ def merge(kraken_assignment_files, kraken_report_files, out_prefix):
     print(f"Save results to {out_prefix}.kraken_assignments.tsv and {out_prefix}.kraken_report.txt")
     merged_assignments.save()
     merged_reports.save(f"{out_prefix}.kraken_report.txt")
+
+# Main method
+def main():
+    # Parse arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-r",
+        dest="in_reports",
+        nargs ='+',
+        required=True,
+        help='A number of kraken reports for the same dataset ordered by preference (later=higher)'
+    )
+    parser.add_argument(
+            "-a",
+            dest="in_assignments",
+            nargs ='+',
+            required=True,
+            help='A number of kraken assignment files for the same dataset ordered by preference (later=higher)'
+        )
+
+    args = parser.parse_args()
+
+    # Start Program
+    now = datetime.now()
+    time = now.strftime("%m/%d/%Y, %H:%M:%S")
+    sys.stdout.write("PROGRAM START TIME: " + time + "\n")
+
+    merge(args.in_assignments, args.in_reports, "merged")
+
+    now = datetime.now()
+    time = now.strftime("%m/%d/%Y, %H:%M:%S")
+    sys.stdout.write("PROGRAM END TIME: " + time + "\n")
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/taxonomy.py
+++ b/bin/taxonomy.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import os
 import sys
 from collections import defaultdict

--- a/bin/taxonomy.py
+++ b/bin/taxonomy.py
@@ -26,6 +26,12 @@ class TaxonEntry:
         self.name = name
         self.rank = rank
 
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        else:
+            return False
+
     def print(self):
         """
         Print the attributes of TaxonEntry as a string
@@ -53,6 +59,12 @@ class Taxonomy:
         if taxonomy_dir and taxon_ids:
             self.load_entries(taxonomy_dir, taxon_ids)
 
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        else:
+            return False
+
     def load_parents_and_children(self, taxonomy_dir):
         """
         Loads the parent child relationships from the "nodes.dmp" file in the taxonomy directory.
@@ -62,6 +74,7 @@ class Taxonomy:
             taxonomy_dir (str): The unzipped directory downloaded from NCBI taxonomy.
         """
         taxonomy = os.path.join(taxonomy_dir, "nodes.dmp")
+
         try:
             with open(taxonomy, "r") as f:
                 for line in f:

--- a/conf/climb.config
+++ b/conf/climb.config
@@ -8,13 +8,6 @@ params {
     max_cpus                   = 16
     max_time                   = '240.h'
 
-    k2_port = 8080
-    k2_host = "10.1.185.58"
-
-    taxonomy = "/shared/public/db/taxonomy/"
-    database = "/shared/public/db/kraken2/k2_pluspf/"
-    database_set = "PlusPF"
-
     reject_human = true
-    max_human_reads_before_rejection = 1000
+    max_human_reads_before_rejection = 10000
 }

--- a/conf/local.config
+++ b/conf/local.config
@@ -8,5 +8,23 @@ params {
     sourmash_db_includes = "viral fungi"
     centrifuge_db_name = "p_compressed+h+v"
     centrifuge_remote = "https://genome-idx.s3.amazonaws.com/centrifuge/p_compressed%2Bh%2Bv.tar.gz"
+
+    kraken_database = [
+        "default" : [
+            "name": "PlusPF-8",
+            "path": null,
+            "host": "localhost",
+            "port": 8080
+        ],
+        "viral" : [
+            "name": "Viral",
+            "path": null,
+            "host": "localhost",
+            "port": 8081
+        ]
+    ]
     raise_server = true
+
+    reject_human = false
+    max_human_reads_before_rejection = 100
 }

--- a/conf/params.config
+++ b/conf/params.config
@@ -90,15 +90,6 @@ params {
             ]
     ]
 
-    kraken_servers = [
-        "default" : [
-
-            ],
-        "viral" : [
-
-            ]
-        ]
-
     taxonomy = null
     default_taxonomy = 'https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz'
 

--- a/conf/params.config
+++ b/conf/params.config
@@ -48,54 +48,73 @@ params {
     read_type = null
     paired = false
 
-    database = null
-    taxonomy = null
-    bracken_dist = null
-    bracken_length = null
-    bracken_level = 'S'
-    database_set = "Viral"
     database_sets = [
         'Viral': [
             'database': 'https://genome-idx.s3.amazonaws.com/kraken/k2_viral_20231009.tar.gz',
-            'taxonomy': 'https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz',
         ],
         'MinusB': [
             'database': 'https://genome-idx.s3.amazonaws.com/kraken/k2_minusb_20231009.tar.gz',
-            'taxonomy': 'https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz'
         ],
         'EuPath': [
             'database': 'https://genome-idx.s3.amazonaws.com/kraken/k2_eupathdb48_20230407.tar.gz',
-            'taxonomy': 'https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz'
         ],
         'Standard': [
             'database': 'https://genome-idx.s3.amazonaws.com/kraken/k2_standard_20231009.tar.gz',
-            'taxonomy': 'https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz'
         ],
         'PlusPF-8': [
             'database': 'https://genome-idx.s3.amazonaws.com/kraken/k2_pluspf_08gb_20231009.tar.gz',
-            'taxonomy': 'https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz'
         ],
         'PlusPF-16': [
             'database': 'https://genome-idx.s3.amazonaws.com/kraken/k2_pluspf_16gb_20231009.tar.gz',
-            'taxonomy': 'https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz'
         ],
         'PlusPF': [
             'database': 'https://genome-idx.s3.amazonaws.com/kraken/k2_pluspf_20231009.tar.gz',
-             'taxonomy': 'https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz'
         ],
         'ncbi_16s_18s': [
             'database': 'https://ont-exd-int-s3-euwst1-epi2me-labs.s3.amazonaws.com/wf-metagenomics/ncbi_16s_18s/ncbi_targeted_loci_kraken2.tar.gz',
-            'taxonomy': 'https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz'
         ]
     ]
 
+    kraken_database = [
+        "default" : [
+            "name": "PlusPF-8",
+            "path": null,
+            "host": "localhost",
+            "port": 8080
+            ],
+        "viral" : [
+            "name": "Viral",
+            "path": null,
+            "host": "localhost",
+            "port": 8081
+            ]
+    ]
+
+    kraken_servers = [
+        "default" : [
+
+            ],
+        "viral" : [
+
+            ]
+        ]
+
+    taxonomy = null
+    default_taxonomy = 'https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz'
+
     kraken_report = null
-    bracken_report = null
     kraken_assignments = null
     kraken_confidence = 0.05
+    kraken_clients = 2
+
+    run_viral_reclassification = false
+
     run_bracken = false
+    bracken_report = null
+    bracken_dist = null
+    bracken_length = null
+    bracken_level = 'S'
     additional_bracken_jsons = null
-    default_taxonomy = 'https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz'
 
     spike_ins = null
     spike_in_dict = "${projectDir}/resources/spike_ins/spike_ins.json"
@@ -148,10 +167,6 @@ params {
 
     disable_ping = false
     threads = 2
-    kraken_clients = 2
-    k2_port = 8080
-    k2_host = 'localhost'
-    kraken_confidence = 0.05
     process_label = "scylla"
     monochrome_logs = false
 

--- a/conf/params.config
+++ b/conf/params.config
@@ -77,7 +77,7 @@ params {
 
     kraken_database = [
         "default" : [
-            "name": "PlusPF-8",
+            "name": "PlusPF",
             "path": null,
             "host": "localhost",
             "port": 8080

--- a/modules/centrifuge_classification.nf
+++ b/modules/centrifuge_classification.nf
@@ -1,5 +1,5 @@
 // This file contains workflow to classify with centrifuge
-include { unpack_taxonomy } from '../modules/kraken_server'
+include { unpack_taxonomy } from '../modules/setup_taxonomy'
 
 process unpack_database {
     label "process_single"

--- a/modules/check_hcid_status.nf
+++ b/modules/check_hcid_status.nf
@@ -10,7 +10,7 @@ process check_hcid {
     publishDir "${params.outdir}/${unique_id}/qc/", mode: 'copy'
 
     input:
-        tuple val(unique_id), path(kreport), path(reads)
+        tuple val(unique_id), val(database_name), path(kreport), path(reads)
         path taxonomy
         path hcid_defs
         path hcid_refs
@@ -49,7 +49,7 @@ workflow check_hcid_status {
         check_hcid(input_ch, taxonomy, hcid_defs, hcid_refs)
 
         empty_file = file("$projectDir/resources/empty_file")
-        kreport_ch.map{unique_id, kreport -> [unique_id, empty_file]}
+        kreport_ch.map{unique_id, database_name, kreport -> [unique_id, empty_file]}
             .concat(check_hcid.out.warnings)
             .collectFile()
             .map{f -> [f.simpleName, f]}
@@ -65,7 +65,7 @@ workflow {
     if (unique_id == "null") {
        unique_id = "${fastq.simpleName}"
     }
-    kreport_ch = Channel.of([unique_id, kreport])
+    kreport_ch = Channel.of([unique_id, "default", kreport])
     fastq_ch = Channel.of([unique_id, fastq])
 
     taxonomy_dir = file(params.taxonomy, type: "dir", checkIfExists:true)

--- a/modules/check_spike_status.nf
+++ b/modules/check_spike_status.nf
@@ -12,7 +12,7 @@ process check_spike_ins {
     publishDir "${params.outdir}/${unique_id}/classifications", mode: "copy", overwrite: true, pattern: "*.json"
 
     input:
-        tuple val(unique_id), path(kreport), path(reads)
+        tuple val(unique_id), val(database_name), path(kreport), path(reads)
         val spike_ins
         path spike_in_dict
         path spike_in_ref_dir
@@ -52,7 +52,7 @@ workflow check_spike_status {
         check_spike_ins(input_ch, spike_ins, spike_in_dict, spike_in_ref_dir)
 
         empty_file = file("$baseDir/resources/empty_file")
-        kreport_ch.map{unique_id, kreport -> [unique_id, empty_file]}
+        kreport_ch.map{unique_id, database_name, kreport -> [unique_id, empty_file]}
             .concat(check_spike_ins.out.status)
             .collectFile()
             .map{f -> [f.simpleName, f]}

--- a/modules/extract_all.nf
+++ b/modules/extract_all.nf
@@ -425,6 +425,29 @@ workflow extract_fractions {
         virus = bgzip_extracted_taxa.out.virus
 }
 
+workflow extract_virus_fraction {
+    take:
+        fastq_ch
+        assignments_ch
+        kreport_ch
+        taxonomy_dir
+    main:
+         assignments_ch.combine(kreport_ch, by:[0,1]).set{ classify_ch }
+         fastq_ch.combine(classify_ch, by: 0)
+                 .set{ full_extract_ch }
+
+        if ( params.paired ){
+            extract_paired_virus_and_unclassified(full_extract_ch, taxonomy_dir)
+            extract_paired_virus_and_unclassified.out.reads.set{extracted_fractions}
+        } else {
+            extract_virus_and_unclassified(full_extract_ch, taxonomy_dir)
+            extract_virus_and_unclassified.out.reads.set{extracted_fractions}
+        }
+        bgzip_extracted_taxa(extracted_fractions, "read_fractions")
+    emit:
+        virus = bgzip_extracted_taxa.out.virus
+}
+
 
 workflow extract_all {
     take:

--- a/modules/extract_all.nf
+++ b/modules/extract_all.nf
@@ -18,7 +18,7 @@ process split_kreport {
     publishDir "${params.outdir}/${unique_id}/classifications", mode: "copy", overwrite: false, pattern: "*.json"
 
     input:
-        tuple val(unique_id), path(kreport)
+        tuple val(unique_id), val(database_name), path(kreport)
     output:
         tuple val(unique_id), path("*.kreport_split.txt"), emit: reports
         tuple val(unique_id), path("*.json"), emit: json
@@ -43,7 +43,7 @@ process extract_taxa_paired_reads {
     container "biocontainers/pyfastx:2.0.1--py39h3d4b85c_0"
 
     input:
-        tuple val(unique_id), path(fastq1), path(fastq2), path(kraken_assignments), path(kreport), val(taxon_rank), val(min_reads), val(min_percent)
+        tuple val(unique_id), path(fastq1), path(fastq2), val(database_name), path(kraken_assignments), path(kreport), val(taxon_rank), val(min_reads), val(min_percent)
         path taxonomy_dir
     output:
         tuple val(unique_id), path("*.fastq"), emit: reads
@@ -86,7 +86,7 @@ process extract_taxa_reads {
     container "biocontainers/pyfastx:2.0.1--py39h3d4b85c_0"
 
     input:
-        tuple val(unique_id), path(fastq), path(kraken_assignments), path(kreport), val(taxon_rank), val(min_reads), val(min_percent)
+        tuple val(unique_id), path(fastq), val(database_name), path(kraken_assignments), path(kreport), val(taxon_rank), val(min_reads), val(min_percent)
         path taxonomy_dir
     output:
         tuple val(unique_id), path("*.f*q"), emit: reads
@@ -128,7 +128,7 @@ process extract_paired_virus_and_unclassified {
     container "biocontainers/pyfastx:2.0.1--py39h3d4b85c_0"
 
     input:
-        tuple val(unique_id), path(fastq1), path(fastq2), path(kraken_assignments), path(kreport)
+        tuple val(unique_id), path(fastq1), path(fastq2), val(database_name), path(kraken_assignments), path(kreport)
         path taxonomy_dir
     output:
         tuple val(unique_id), path("*.fastq"), emit: reads
@@ -158,7 +158,7 @@ process extract_virus_and_unclassified {
     container "biocontainers/pyfastx:2.0.1--py39h3d4b85c_0"
 
     input:
-        tuple val(unique_id), path(fastq), path(kraken_assignments), path(kreport)
+        tuple val(unique_id), path(fastq), val(database_name), path(kraken_assignments), path(kreport)
         path taxonomy_dir
     output:
         tuple val(unique_id), path("*.fastq"), emit: reads
@@ -188,7 +188,7 @@ process extract_paired_virus {
     container "biocontainers/pyfastx:2.0.1--py39h3d4b85c_0"
 
     input:
-        tuple val(unique_id), path(fastq1), path(fastq2), path(kraken_assignments), path(kreport)
+        tuple val(unique_id), path(fastq1), path(fastq2), val(database_name), path(kraken_assignments), path(kreport)
         path taxonomy_dir
     output:
         tuple val(unique_id), path("*.fastq"), emit: reads
@@ -217,7 +217,7 @@ process extract_virus {
     container "biocontainers/pyfastx:2.0.1--py39h3d4b85c_0"
 
     input:
-        tuple val(unique_id), path(fastq), path(kraken_assignments), path(kreport)
+        tuple val(unique_id), path(fastq), val(database_name), path(kraken_assignments), path(kreport)
         path taxonomy_dir
     output:
         tuple val(unique_id), path("*.fastq"), emit: reads
@@ -246,7 +246,7 @@ process extract_paired_dehumanised {
     container "biocontainers/pyfastx:2.0.1--py39h3d4b85c_0"
 
     input:
-        tuple val(unique_id), path(fastq1), path(fastq2), path(kraken_assignments), path(kreport)
+        tuple val(unique_id), path(fastq1), path(fastq2), val(database_name), path(kraken_assignments), path(kreport)
         path taxonomy_dir
     output:
         tuple val(unique_id), path("*.fastq"), emit: reads
@@ -276,7 +276,7 @@ process extract_dehumanised {
     container "biocontainers/pyfastx:2.0.1--py39h3d4b85c_0"
 
     input:
-        tuple val(unique_id), path(fastq), path(kraken_assignments), path(kreport)
+        tuple val(unique_id), path(fastq), val(database_name), path(kraken_assignments), path(kreport)
         path taxonomy_dir
     output:
         tuple val(unique_id), path("*.fastq"), emit: reads
@@ -359,8 +359,8 @@ workflow extract_taxa {
                     .map { unique_id, kreport, key -> [unique_id, kreport, thresholds.get(key,"false").get("taxon_rank","false"), thresholds.get(key,"false").get("min_reads","false"), thresholds.get(key,"false").get("min_percent","false")] }
                     .set{ kreport_params_ch }
 
-        fastq_ch.combine(assignments_ch, by: 0)
-                .combine(kreport_params_ch, by: 0)
+        assignments_ch.combine(kreport_params_ch, by:0).set{ classify_ch }
+        fastq_ch.combine(classify_ch, by: 0)
                 .set{ extract_ch }
 
         if ( params.paired ){
@@ -392,9 +392,9 @@ workflow extract_fractions {
         kreport_ch
         taxonomy_dir
     main:
-        fastq_ch.combine(assignments_ch, by: 0)
-                .combine(kreport_ch, by: 0)
-                .set{ full_extract_ch }
+         assignments_ch.combine(kreport_ch, by:[0,1]).set{ classify_ch }
+         fastq_ch.combine(classify_ch, by: 0)
+                 .set{ full_extract_ch }
 
         if ( params.paired ){
             extract_paired_dehumanised(full_extract_ch, taxonomy_dir)
@@ -451,8 +451,8 @@ workflow {
     }
 
     fastq_ch = Channel.of([unique_id, fastq])
-    assignments_ch = Channel.of([unique_id, assignments])
-    kreport_ch = Channel.of([unique_id, kreport])
+    assignments_ch = Channel.of([unique_id, "Viral", assignments])
+    kreport_ch = Channel.of([unique_id, "Viral", kreport])
     taxonomy_dir = file(params.taxonomy, type: "dir", checkIfExists:true)
 
     extract_all(fastq_ch, assignments_ch, kreport_ch, taxonomy_dir)

--- a/modules/generate_report.nf
+++ b/modules/generate_report.nf
@@ -13,7 +13,7 @@ process make_report {
     container "${params.wf.container}:${params.wf.container_version}"
     
     input:
-        tuple val(unique_id), path(stats), path(lineages), path(warnings)
+        tuple val(unique_id), path(stats), val(database_name), path(lineages), path(warnings)
         path template
     output:
         tuple val(unique_id), path("${unique_id}_report.html")
@@ -21,10 +21,10 @@ process make_report {
         report_name = "${unique_id}"
         if ( params.run_sourmash ){
             classifier = "Sourmash"
-            classification_database = "${params.sourmash_db_name}"
+            classification_database = "${database_name}"
         } else {
             classifier = "Kraken"
-            classification_database = "${params.database_set}"
+            classification_database = "${database_name}"
         }
     """
     make_report.py \

--- a/modules/kraken_client.nf
+++ b/modules/kraken_client.nf
@@ -14,150 +14,18 @@ process kraken2_client {
     publishDir "${params.outdir}/${unique_id}/classifications", mode: "copy"
 
     input:
+        tuple val(database_name), val(host), val(port)
         tuple val(unique_id), path(fastq)
 
     output:
-        tuple val(unique_id), path("${params.database_set}.kraken_assignments.tsv"), emit: assignments
-        tuple val(unique_id), path("${params.database_set}.kraken_report.txt"), emit: report
+        tuple val(unique_id), val(database_name), path("${database_name}.kraken_assignments.tsv"), emit: assignments
+        tuple val(unique_id), val(database_name), path("${database_name}.kraken_report.txt"), emit: report
 
     script:
     """
     kraken2_client \
-        --port ${params.k2_port} --host-ip ${params.k2_host} \
-        --report "${params.database_set}.kraken_report.txt" \
-        --sequence ${fastq} > "${params.database_set}.kraken_assignments.tsv"
+        --port ${port} --host-ip ${host} \
+        --report "${database_name}.kraken_report.txt" \
+        --sequence ${fastq} > "${database_name}.kraken_assignments.tsv"
     """
 }
-
-
-process determine_bracken_length {
-    label "process_low"
-
-    conda "anaconda::sed=4.8"
-    container "${params.wf.container}:${params.wf.container_version}"
-
-    input:
-        path database
-    output:
-        env BRACKEN_LENGTH
-    """
-    if [[ -f "${database}"/database${params.bracken_length}mers.kmer_distrib ]]; then
-        BRACKEN_LENGTH="${params.bracken_length}"
-    else
-        cd "${database}"
-        BRACKEN_LENGTH=\$(ls -v1 *.kmer_distrib | tail -1 | sed -e "s@^database@@" -e "s@mers.kmer_distrib@@")
-        cd ..
-    fi
-    """
-}
-
-// this fails if the kraken file input is empty - currently have no check that it is populated
-process bracken {
-    
-    label "process_low"
-
-    errorStrategy {"ignore"}
-
-    publishDir "${params.outdir}/${unique_id}/classifications", mode: "copy"
-
-    conda "bioconda::bracken=2.7"
-    container "biocontainers/bracken:2.9--py39h1f90b4d_0"
-
-    input:
-        tuple val(unique_id), path(kraken_report)
-        path database
-        val bracken_length
-    output:
-        tuple val(unique_id), path("${params.database_set}.bracken_report.txt"), path("${params.database_set}.bracken_summary.txt"), emit: summary
-        tuple val(unique_id), path("${params.database_set}.bracken_report.txt"), emit: report
-    """
-    bracken \
-          -d "${database}" \
-          -i "${kraken_report}" \
-          -r "${bracken_length}" \
-          -l "${params.bracken_level}" \
-          -o "${params.database_set}.bracken_summary.txt" \
-          -w "${params.database_set}.bracken_report.txt"
-    """
-}
-
-process bracken_to_json {
-    
-    label "process_low"
-
-    publishDir "${params.outdir}/${unique_id}/classifications", mode: "copy"
-    
-    conda "bioconda::taxonkit=0.15.1 python=3.10"
-    container "${params.wf.container}:${params.wf.container_version}"
-
-    input:
-        tuple val(unique_id), path(bracken_report), path(bracken_summary)
-        path taxonomy_dir
-    output:
-        tuple val(unique_id), path("${params.database_set}.bracken.json")
-
-    """
-    cat "${bracken_summary}" | cut -f2,6 | tail -n+2 > taxacounts.txt
-    cat "${bracken_summary}" | cut -f2 | tail -n+2 > taxa.txt
-    taxonkit lineage --data-dir ${taxonomy_dir}  -R taxa.txt  > lineages.txt
-    aggregate_lineages_bracken.py \\
-            -i "lineages.txt" -b "taxacounts.txt" \\
-            -u "${bracken_report}" \\
-            -p "temp_bracken"
-    file1=`cat *.json`
-    echo "{"'"${params.database_set}"'": "\$file1"}" >> "${params.database_set}.bracken.json"
-    """
-}
-
-process kraken_to_json {
-
-    label "process_low"
-
-    publishDir "${params.outdir}/${unique_id}/classifications", mode: "copy"
-
-    conda "bioconda::taxonkit=0.15.1 python=3.10"
-    container "${params.wf.container}:${params.wf.container_version}"
-
-
-    input:
-        tuple val(unique_id), path(kraken_report)
-        path taxonomy_dir
-    output:
-       tuple val(unique_id), path("${params.database_set}.kraken.json")
-
-    """
-    cat "${kraken_report}" | cut -f5,3 | tail -n+3 > taxacounts.txt
-    cat "${kraken_report}" | cut -f5 | tail -n+3 > taxa.txt
-    taxonkit lineage --data-dir ${taxonomy_dir}  -R taxa.txt  > lineages.txt
-    aggregate_lineages_bracken.py \\
-            -i "lineages.txt" -b "taxacounts.txt" \\
-            -u "${kraken_report}" \\
-            -p "temp_kraken"
-    file1=`cat *.json`
-    echo "{"'"${params.database_set}"'": "\$file1"}" >> "${params.database_set}.kraken.json"
-    """
-}
-
-
-workflow run_kraken_and_bracken {
-    take:
-        fastq_ch
-        database
-        taxonomy
-    main:
-        unique_id = "test"
-        kraken2_client(fastq_ch)
-        if (params.run_bracken) {
-            bracken_length = determine_bracken_length(database)
-            bracken(kraken2_client.out.report, database, bracken_length)
-
-        }
-        kraken_to_json(kraken2_client.out.report, taxonomy)
-        out_json = kraken_to_json.out
-        out_report = kraken2_client.out.report
-    emit:
-        assignments = kraken2_client.out.assignments
-        kreport = out_report
-        json = out_json
-}
-

--- a/modules/kraken_server.nf
+++ b/modules/kraken_server.nf
@@ -123,6 +123,26 @@ workflow get_server {
         server = server_ch
 }
 
+workflow get_default_server {
+    take:
+        raise_server
+    main:
+        get_server("default", raise_server)
+    emit:
+        database = get_server.out.database
+        server = get_server.out.server
+}
+
+workflow get_viral_server {
+    take:
+        raise_server
+    main:
+        get_server("viral", raise_server)
+    emit:
+        database = get_server.out.database
+        server = get_server.out.server
+}
+
 workflow {
     // Grab database files
     //get_server("default", true)

--- a/modules/kraken_server.nf
+++ b/modules/kraken_server.nf
@@ -75,14 +75,6 @@ process stop_kraken_server {
     """
 }
 
-workflow stop_server {
-    take:
-        server
-        stop
-    main:
-        stop_kraken_server(server, stop)
-}
-
 workflow get_server_address {
     take:
         server_key
@@ -141,6 +133,32 @@ workflow get_viral_server {
     emit:
         database = get_server.out.database
         server = get_server.out.server
+}
+
+workflow stop_server {
+    take:
+       server
+       stop
+    main:
+        stop_kraken_server(server, stop)
+}
+
+workflow stop_default_server {
+    take:
+       server
+       stop
+    main:
+        println("Stopping server for ${kraken_database.default.name}")
+        stop_kraken_server(server, stop)
+}
+
+workflow stop_viral_server {
+    take:
+       server
+       stop
+    main:
+        println("Stopping server for ${kraken_database.viral.name}")
+        stop_kraken_server(server, stop)
 }
 
 workflow {

--- a/modules/setup_database.nf
+++ b/modules/setup_database.nf
@@ -1,0 +1,76 @@
+process unpack_database {
+    label "process_single"
+    storeDir "${params.store_dir}/kraken/${database_name}"
+    input:
+        val(database_name)
+        path(database_path)
+    output:
+        tuple val(database_name), path("database_dir")
+    """
+    if [[ "${database_path}" == *.tar.gz ]]
+    then
+        mkdir database_dir
+        tar xf "${database_path}" -C database_dir
+    elif [ -d "${database_path}" ]
+    then
+        mv "${database_path}" database_dir
+    else
+        echo "Error: database is neither .tar.gz nor a dir"
+        echo "Exiting".
+        exit 1
+    fi
+    """
+}
+
+
+workflow setup_database {
+    take:
+        database_key
+    main:
+        databases = params.kraken_database
+        database_data = databases.get(database_key)
+        if (!databases.containsKey(database_key) || !database_data) {
+            keys = databases.keySet()
+            throw new Exception("Source $database_key is invalid, must be one of $keys")
+        }
+        database_name = database_data.get("name")
+        database_path = database_data.get("path")
+
+        if (!database_path) {
+            sources = params.database_sets
+            source_data = sources.get(database_name, false)
+            if (!sources.containsKey(database_name) || !source_data) {
+                keys = sources.keySet()
+                throw new Exception("Source $database_name is invalid, must be one of $keys")
+            }
+        }
+
+        // Grab database files
+        if (database_path) {
+            found_database = file(database_path, type: "dir", checkIfExists:true)
+            database = Channel.of([database_name, found_database])
+        } else {
+            default_database = source_data.get("database", false)
+            if (!default_database) {
+                throw new Exception(
+                    "Error: Source $database_name does not include a database for "
+                    + "use with kraken, please choose another source or "
+                    + "provide a custom database.")
+            }
+
+            input_database = file("${params.store_dir}/kraken/$database_name/database_dir")
+            if (input_database.isEmpty()) {
+                database = unpack_database(database_name, default_database)
+            } else {
+                database = Channel.of([database_name, input_database])
+            }
+        }
+    emit:
+        database = database
+}
+
+
+workflow {
+    setup_database("default")
+}
+

--- a/modules/setup_taxonomy.nf
+++ b/modules/setup_taxonomy.nf
@@ -1,0 +1,45 @@
+process unpack_taxonomy {
+    label "process_single"
+    storeDir "${params.store_dir}"
+    input:
+        path taxonomy
+    output:
+        path "taxonomy_dir"
+    """
+    if [[ "${taxonomy}" == *.tar.gz ]]
+    then
+        mkdir taxonomy_dir
+        tar xf "${taxonomy}" -C taxonomy_dir
+    elif [ -d "${taxonomy}" ]
+    then
+        mv "${taxonomy}" taxonomy_dir
+    else
+        echo "Error: taxonomy is neither .tar.gz nor a dir"
+        echo "Exiting".
+        exit 1
+    fi
+    """
+}
+
+
+workflow setup_taxonomy {
+    main:
+        if (params.taxonomy) {
+            taxonomy = file(params.taxonomy, type: "dir", checkIfExists:true)
+        } else {
+            input_taxonomy = file("${params.store_dir}/taxonomy_dir")
+            if (input_taxonomy.isEmpty()) {
+                taxonomy = unpack_taxonomy(params.default_taxonomy)
+            } else {
+                taxonomy = input_taxonomy
+            }
+        }
+    emit:
+        taxonomy = taxonomy
+}
+
+
+workflow {
+    setup_taxonomy()
+}
+

--- a/modules/sourmash_classification.nf
+++ b/modules/sourmash_classification.nf
@@ -1,5 +1,5 @@
 // This file contains workflow to classify with sourmash
-include { unpack_taxonomy } from '../modules/kraken_server'
+include { unpack_taxonomy } from '../modules/setup_taxonomy'
 
 process unpack_database {
     label "process_single"

--- a/subworkflows/classify.nf
+++ b/subworkflows/classify.nf
@@ -1,0 +1,118 @@
+include { kraken_classify; kraken_to_json } from '../modules/kraken_classification'
+include { sourmash_classify } from '../modules/sourmash_classification'
+include { centrifuge_classify } from '../modules/centrifuge_classification'
+include { extract_virus_fraction } from '../modules/extract_all'
+include { preprocess } from '../modules/preprocess'
+include { setup_taxonomy } from '../modules/setup_taxonomy'
+
+workflow default_classify {
+    take:
+        concat_fastq_ch
+        raise_server
+    main:
+        kraken_classify(concat_fastq_ch, "default", raise_server)
+
+        if (params.run_sourmash){
+            sourmash_classify(concat_fastq_ch)
+        }
+        if (params.run_centrifuge){
+            centrifuge_classify(concat_fastq_ch)
+        }
+    emit:
+        assignments = kraken_classify.out.assignments
+        kreport = kraken_classify.out.kreport
+}
+
+workflow viral_classify {
+    take:
+        concat_fastq_ch
+        raise_server
+    main:
+        kraken_classify(concat_fastq_ch, "viral", raise_server)
+    emit:
+        assignments = kraken_classify.out.assignments
+        kreport = kraken_classify.out.kreport
+}
+
+process merge_classifications {
+    label "process_single"
+
+    conda "bioconda::mappy=2.28 bioconda::pyfastx=2.1.0"
+    container "community.wave.seqera.io/library/mappy_pyfastx:b4cc4b80f5e5decf"
+
+    publishDir "${params.outdir}/${unique_id}/classifications/", mode: 'copy'
+
+    input:
+        tuple val(unique_id), path(default_assignments), path(default_kreport), path(viral_assignments), path(viral_kreport)
+    output:
+        tuple val(unique_id), val("merged"), path("merged.kraken_assignments.tsv"), emit: assignments
+        tuple val(unique_id), val("merged"), path("merged.kraken_report.txt"), emit: kreport
+    script:
+        """
+        ../../../bin/merge.py \
+          -a ${default_assignments} ${viral_assignments} \
+          -r ${default_kreport} ${viral_kreport}
+        """
+}
+
+workflow classify {
+    take:
+        fastq_ch
+        concat_fastq_ch
+        raise_server
+    main:
+        default_classify(concat_fastq_ch, raise_server)
+
+        if (params.run_viral_reclassification) {
+            setup_taxonomy()
+            extract_virus_fraction(fastq_ch, default_classify.out.assignments, default_classify.out.kreport, setup_taxonomy.out)
+            viral_classify(extract_virus_fraction.out.virus, raise_server)
+            default_classify.out.assignments
+                .join(default_classify.out.kreport, by:[0,1])
+                .map{ unique_id, database_name, assignments, kreport -> [unique_id, assignments, kreport]}
+                .set{ default_ch }
+            viral_classify.out.assignments
+                .join(viral_classify.out.kreport, by:[0,1])
+                .map{ unique_id, database_name, assignments, kreport -> [unique_id, assignments, kreport]}
+                .set{ viral_ch }
+            default_ch.join( viral_ch , by:0).set{ merge_ch }
+            merge_classifications(merge_ch)
+            assignments = merge_classifications.out.assignments
+            kreport = merge_classifications.out.kreport
+        } else {
+            assignments = default_classify.out.assignments
+            kreport = default_classify.out.kreport
+        }
+
+    emit:
+        assignments = assignments
+        kreport = kreport
+}
+
+workflow {
+    unique_id = "${params.unique_id}"
+
+    // check input fastq exists
+    if (unique_id == "null") {
+        if (params.fastq) {
+            fastq = file(params.fastq, type: "file", checkIfExists:true)
+            unique_id = "${fastq.simpleName}"
+        } else if (params.fastq_dir) {
+            fastq_dir = file(params.fastq_dir, type: "dir", checkIfExists:true)
+            unique_id = "${fastq_dir.simpleName}"
+        } else if (params.paired && params.fastq1 && params.fastq2) {
+            fastq1 = file(params.fastq1, type: "file", checkIfExists:true)
+            unique_id = "${fastq1.simpleName}"
+        } else if (params.run_dir) {
+            run_dir = file(params.run_dir, type: "dir", checkIfExists:true)
+            unique_id = "${run_dir.simpleName}"
+        } else {
+            exit 1, "One of fastq, fastq_dir or fastq1 and fastq2 need to be provided -- aborting"
+        }
+    }
+
+    preprocess(unique_id)
+    classify(preprocess.out.processed_fastq, preprocess.out.combined_fastq, params.raise_server)
+}
+
+

--- a/subworkflows/classify_and_report.nf
+++ b/subworkflows/classify_and_report.nf
@@ -1,9 +1,10 @@
-include { kraken_classify } from '../modules/kraken_classification'
+include { kraken_classify; kraken_to_json } from '../modules/kraken_classification'
 include { sourmash_classify } from '../modules/sourmash_classification'
 include { centrifuge_classify } from '../modules/centrifuge_classification'
 include { qc_checks } from '../modules/qc_checks'
 include { check_hcid_status } from '../modules/check_hcid_status'
 include { check_spike_status } from '../modules/check_spike_status'
+include { setup_taxonomy } from '../modules/setup_taxonomy'
 include { generate_report } from '../modules/generate_report'
 
 
@@ -11,10 +12,12 @@ workflow classify_and_report {
     take:
         fastq_ch
         concat_fastq_ch
+        database_key
         raise_server
     main:
         qc_checks(fastq_ch)
-        kraken_classify(concat_fastq_ch, raise_server)
+        kraken_classify(concat_fastq_ch, database_key, raise_server)
+
         if (params.run_sourmash){
             sourmash_classify(concat_fastq_ch)
         }
@@ -22,32 +25,22 @@ workflow classify_and_report {
             centrifuge_classify(concat_fastq_ch)
         }
 
-        if (params.additional_bracken_jsons) {
-            jsons = Channel.of(file(params.additional_bracken_jsons, type: "file", checkIfExists:true))
-            fastq_ch.map{ it -> it[0] }
-                .combine(jsons)
-                .concat(kraken_classify.out.json)
-                .groupTuple()
-                .set { classified_jsons }
-        } else {
-            kraken_classify.out.json
-                .set { classified_jsons }
-        }
-
-        check_hcid_status(kraken_classify.out.kreport, concat_fastq_ch, kraken_classify.out.taxonomy)
+        setup_taxonomy()
+        check_hcid_status(kraken_classify.out.kreport, concat_fastq_ch, setup_taxonomy.out.taxonomy)
         
         if (params.spike_ins) {
             check_spike_status(kraken_classify.out.kreport, concat_fastq_ch)
         }
 
-        qc_checks.out.combine(classified_jsons, by: 0)
+        kraken_to_json(kraken_classify.out.kreport, setup_taxonomy.out.taxonomy)
+        qc_checks.out.combine(kraken_to_json.out, by: 0)
             .join(check_hcid_status.out).set { report_ch }
         generate_report( report_ch )
     emit:
         assignments = kraken_classify.out.assignments
         kreport = kraken_classify.out.kreport
         report = generate_report.out
-        taxonomy = kraken_classify.out.taxonomy
+        taxonomy = setup_taxonomy.out.taxonomy
 
 }
 
@@ -73,7 +66,7 @@ workflow {
 
     input_fastq.map { it -> [unique_id, it] }.set { fastq_ch }
     input_fastq.map { it -> [unique_id, it] }.set { concat_fastq_ch }
-    classify_and_report(fastq_ch, concat_fastq_ch, "${params.raise_server}")
+    classify_and_report(fastq_ch, concat_fastq_ch, "default", params.raise_server)
 }
 
 

--- a/subworkflows/ingest.nf
+++ b/subworkflows/ingest.nf
@@ -12,7 +12,7 @@ workflow ingest {
 
         preprocess(unique_id)
 
-        classify_and_report(preprocess.out.processed_fastq, preprocess.out.combined_fastq, "default", params.raise_server)
+        classify_and_report(preprocess.out.processed_fastq, preprocess.out.combined_fastq, params.raise_server)
         extract_all(preprocess.out.processed_fastq, classify_and_report.out.assignments, classify_and_report.out.kreport, classify_and_report.out.taxonomy)
 
     emit:

--- a/subworkflows/ingest.nf
+++ b/subworkflows/ingest.nf
@@ -12,7 +12,7 @@ workflow ingest {
 
         preprocess(unique_id)
 
-        classify_and_report(preprocess.out.processed_fastq, preprocess.out.combined_fastq, params.raise_server)
+        classify_and_report(preprocess.out.processed_fastq, preprocess.out.combined_fastq, "default", params.raise_server)
         extract_all(preprocess.out.processed_fastq, classify_and_report.out.assignments, classify_and_report.out.kreport, classify_and_report.out.taxonomy)
 
     emit:

--- a/subworkflows/process_run.nf
+++ b/subworkflows/process_run.nf
@@ -1,6 +1,6 @@
 // workflow to run kraken, check for human, run qc checks and generate html report for a single sample fastq
 include { get_params_and_versions } from '../modules/get_params_and_versions'
-include { get_default_server; get_viral_server; stop_server } from '../modules/kraken_server'
+include { get_default_server; get_viral_server; stop_default_server; stop_viral_server } from '../modules/kraken_server'
 include { classify_and_report } from '../subworkflows/classify_and_report'
 include { classify_virus_fastq } from '../modules/classify_novel_viruses'
 include { extract_all } from '../modules/extract_all'
@@ -81,19 +81,21 @@ workflow process_run {
 
         if (params.raise_server){
             get_default_server(params.raise_server)
-            servers_ch = get_default_server.out.server
+            default_ch = get_default_server.out.server
             if (params.run_viral_reclassification){
                 get_viral_server(params.raise_server)
-                servers_ch.concat(get_viral_server.out.server)
+                viral_ch = get_viral_server.out.server
             }
+            //default_ch.concat(viral_ch).view()
         }
-
 
         process_barcode(barcode_input)
         process_barcode.out.report
-            .map{ barcode_id, barcode_report -> "barcode,filepath,sample_report\n${barcode_id},${barcode_id}/classifications/${params.database_set}.kraken_report.txt,${barcode_id}/${barcode_id}_report.html\n" }.collectFile(name: "${params.outdir}/${unique_id}/samples.csv", sort:true, keepHeader:true, skip:1)
+            .map{ barcode_id, barcode_report -> "barcode,filepath,sample_report\n${barcode_id},${barcode_id}/classifications/merged.kraken_report.txt,${barcode_id}/${barcode_id}_report.html\n" }.collectFile(name: "${params.outdir}/${unique_id}/samples.csv", sort:true, keepHeader:true, skip:1)
 
         if (params.raise_server){
-            stop_server(servers_ch, process_barcode.out.report.collect())
+            stop_default_server(default_ch, process_barcode.out.report.last())
+            if (params.run_viral_reclassification)
+                stop_viral_server(viral_ch, process_barcode.out.report.last())
         }
 }

--- a/subworkflows/process_run.nf
+++ b/subworkflows/process_run.nf
@@ -57,7 +57,7 @@ workflow process_barcode {
         else
             raw_ch = barcode_ch
 
-        classify_and_report(raw_ch, barcode_ch, "default", null)
+        classify_and_report(raw_ch, barcode_ch, false)
         extract_all(raw_ch, classify_and_report.out.assignments, classify_and_report.out.kreport, classify_and_report.out.taxonomy)
         if ( params.classify_novel_viruses ){
             classify_virus_fastq(extract_all.out.virus)


### PR DESCRIPTION
This PR refactors the classification code so that a second classification round can be performed with a targeted viral database.

To trigger viral reclassification, add `--run_viral_reclassification`. This will extract the viral+unclassified file only from the first classification round, classify this file with a viral database, then merge the kraken reports and assignment files (overwriting read assignments/counts where a new classification was made, keeping where it wasn't) before continuing with the downstream pipeline steps (hcid/spike detection, read extraction, report generation).

In the process:
- Database loading/handling has been moved into it's own module
- Taxonomy loading/handling has been moved into it's own module
- kraken2_client and kraken2_server modules have been cleaned of processes which are not directly setting up/running/taking down these server/clients
- kraken_classification just does kraken classification
- A new subworkflow for classification pulls together the different classification options
- Classification-related channels now have input/output triples with `unique_id`,`database_name`,`file` for clarity (rather than pairs `unique_id`,`file`
- Remove the option to add additional bracken jsons/use the bracken json for extraction. It added confusion to the workflow and isn't wanted.

Note there are updates to `report.py`, `assignments.py`, `merge.py` and `taxonomy.py`. These files all exist in a separate project https://github.com/rmcolq/krakenpy (along with unit tests) but given I haven't put it on bioconda they are imported directly at the moment. These classes simplify much of the kraken report handling and I intend to separately continue refactoring other python scripts to import the same classes.

Some command line parameters have changed during this refactor. Namely:
- the default database name was `database_set` and is now `kraken_database.default.name`
- the host server was `k2_host` and is now `kraken_database.default.host`
- the server port was `k2_port` and is now `kraken_database.default.port`
- the stored database was `database` and is now `kraken_database.default.path`
The config file for climb has had defaults removed which no longer apply - can be updated on climb and saved on github if required.

Note that this has been compared for output changes on tests when virus recalling is switched off and kraken is running against the same database and it doesn't change outputs in this case.
