### PR TITLE
Resolve missing total_length.json output file

### DIFF
--- a/bin/get_total_length.py
+++ b/bin/get_total_length.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+import sys
+import argparse
+import pyfastx
+import json
+
+
+def main():
+    # Parse arguments
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "-s",
+        "-s1",
+        "-1",
+        dest="reads1",
+        required=True,
+        help="FASTA/FASTQ File containing the raw reads.",
+    )
+    parser.add_argument(
+        "-s2",
+        "-2",
+        dest="reads2",
+        default="",
+        help="2nd FASTA/FASTQ File containing the raw reads (paired).",
+    )
+
+    parser.set_defaults(append=False)
+    args = parser.parse_args()
+
+    fq = pyfastx.Fastq(args.reads1)
+    total_length = fq.size
+
+    if (args.reads2):
+        fq = pyfastx.Fastq(args.reads2)
+        total_length += fq.size
+
+    with open(f"total_length.json", "w") as f:
+            json.dump({"total_len": total_length}, f)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/extract_all.nf
+++ b/modules/extract_all.nf
@@ -41,9 +41,6 @@ process extract_taxa_paired_reads {
     errorStrategy { task.exitStatus in 2..3 ? "ignore" : "retry" }
     maxRetries 3
 
-    publishDir "${params.outdir}/${unique_id}/qc", pattern: "total_length.json", mode: "copy"
-
-
     conda "bioconda::pyfastx=2.01"
     container "biocontainers/pyfastx:2.0.1--py39h3d4b85c_0"
 
@@ -54,7 +51,6 @@ process extract_taxa_paired_reads {
     output:
     tuple val(unique_id), path("*.fastq"), emit: reads
     tuple val(unique_id), path("${kreport}_summary.json"), emit: summary
-    tuple val(unique_id), path("total_length.json"), emit: length
 
     script:
     extra = ""
@@ -91,8 +87,6 @@ process extract_taxa_reads {
     errorStrategy { task.exitStatus in 2..3 ? "ignore" : "retry" }
     maxRetries 3
 
-    publishDir "${params.outdir}/${unique_id}/qc", pattern: "total_length.json", mode: "copy"
-
     conda "bioconda::pyfastx=2.01"
     container "biocontainers/pyfastx:2.0.1--py39h3d4b85c_0"
 
@@ -103,7 +97,6 @@ process extract_taxa_reads {
     output:
     tuple val(unique_id), path("*.f*q"), emit: reads
     tuple val(unique_id), path("${kreport}_summary.json"), emit: summary
-    tuple val(unique_id), path("total_length.json"), emit: length
 
     script:
     extra = ""

--- a/nextflow.config
+++ b/nextflow.config
@@ -25,7 +25,7 @@ manifest {
     description     = 'Classify metagenomic sequence data from human respiratory infections.'
     mainScript      = 'main.nf'
     nextflowVersion = '>=20.10.0'
-    version         = 'v2.0.2'
+    version         = 'v2.0.3'
 }
 
 profiles {


### PR DESCRIPTION
Problem:
Previously the `total_length.json` file was being created and published during the `extract_taxa_reads` step because that already looped through the files and could collect the info along the way. However, whilst the file was generated when no taxa are extracted, it was not published because nextflow doesn’t publish if the process errors. 

Solution:
Need to collect/output the file in it's own process. Created a small script to do that, and run it during QC step (so can run separately on paired and unpaired files, rather than the concatenated files)

Yields same results on local tests