### PR TITLE
set local profile max mem to 14gb

### DIFF
--- a/conf/local.config
+++ b/conf/local.config
@@ -1,7 +1,7 @@
 params {
     // Max resource options
     // Defaults only, expecting to be overwritten
-    max_memory                       = '16.GB'
+    max_memory                       = '14.GB'
     max_cpus                         = 4
     max_time                         = '48.h'
 


### PR DESCRIPTION
sets the local profile to 14GB to work within github actions

I dont think this would have a dramatic difference on local execution and allows the local profile to be used when running tests in CI.