### PR TITLE
Allow classification and reclassification to run as modules

### DIFF
--- a/modules/utils.nf
+++ b/modules/utils.nf
@@ -2,6 +2,8 @@
 
 import groovy.json.JsonBuilder
 
+include { paired_concatenate    } from '../modules/preprocess'
+
 process get_versions {
 
     conda 'environment.yml'
@@ -89,4 +91,54 @@ workflow get_fastq_ch {
 
     emit:
     fastq_ch
+}
+
+workflow get_fastq_channels {
+    take:
+    unique_id
+
+    main:
+    if (params.run_dir) {
+        run_dir = file("${params.run_dir}", type: "dir", checkIfExists: true)
+        if (params.paired) {
+            fastq_ch = Channel.fromFilePairs("${run_dir}/*_R{1,2}*.f*q*", type: "file", checkIfExists: true)
+            
+            paired_concatenate(fastq_ch)
+            paired_concatenate.out.concatenated_fastq.set { combined_fastq_ch }
+        } 
+        else {
+            fastq_ch = Channel.fromPath("${run_dir}/*", type: "dir", checkIfExists: true, maxDepth: 1).map { [it.baseName, get_fq_files_in_dir(it)] }
+            fastq_ch.tap { combined_fastq_ch }
+        }
+    }
+    else if (params.paired) {
+        fastq1 = file(params.fastq1, type: "file", checkIfExists: true)
+        fastq2 = file(params.fastq2, type: "file", checkIfExists: true)
+        fastq_ch = Channel.from([[unique_id, fastq1, fastq2]])
+
+        paired_concatenate(fastq_ch)
+        paired_concatenate.out.concatenated_fastq.set { combined_fastq_ch }
+    }
+    else if (params.fastq) {
+        fastq = file(params.fastq, type: "file", checkIfExists: true)
+        fastq_ch = Channel.from([[unique_id, fastq]])
+
+        fastq_ch.tap { combined_fastq_ch }
+    }
+    else if (params.fastq_dir) {
+        fastqdir = file("${params.fastq_dir}", type: "dir", checkIfExists: true)
+        Channel.fromPath(fastqdir / "*.f*q*", type: "file")
+            .set { input_ch }
+        fastq_ch = input_ch.map { fastq -> [unique_id, fastq] }
+
+        fastq_ch
+            .map { unique_id, fastq -> [unique_id + ".fq.gz", fastq] }
+            .collectFile()
+            .map { it -> [it.simpleName, it] }
+            .set { combined_fastq_ch }
+    }
+
+    emit:
+    processed_fastq = fastq_ch
+    combined_fastq  = combined_fastq_ch
 }

--- a/subworkflows/run_module.nf
+++ b/subworkflows/run_module.nf
@@ -1,15 +1,15 @@
 // workflow to run kraken, check for human, run qc checks and generate html report for a single sample fastq
-include { get_params_and_versions ; get_fastq_ch } from '../modules/utils'
+include { get_params_and_versions ; get_fastq_channels } from '../modules/utils'
 
 include { preprocess              } from '../modules/preprocess'
 include { qc_checks               } from '../modules/qc_checks'
 include { centrifuge_classify     } from '../modules/centrifuge_classification'
-include { kraken_classify         } from '../modules/kraken_classification'
 include { sourmash_classify       } from '../modules/sourmash_classification'
 include { check_hcid_status       } from '../modules/check_hcid_status'
 include { check_spike_status      } from '../modules/check_spike_status'
 include { extract_all             } from '../modules/extract_all'
 include { classify_virus_fastq    } from '../modules/classify_novel_viruses'
+include { classify ; reclassify   } from '../subworkflows/classify'
 
 workflow run_module {
     take:
@@ -17,8 +17,8 @@ workflow run_module {
 
     main:
     get_params_and_versions(unique_id)
-    get_fastq_ch(unique_id)
-    fastq_ch = get_fastq_ch.out
+    get_fastq_channels(unique_id)
+    fastq_ch = get_fastq_channels.out.processed_fastq
 
     if (params.module == "preprocess") {
         preprocess(unique_id)
@@ -30,7 +30,7 @@ workflow run_module {
         centrifuge_classify(fastq_ch)
     }
     else if (params.module == "kraken_classification") {
-        kraken_classify(fastq_ch, "default", params.raise_server)
+        classify(fastq_ch, get_fastq_channels.out.combined_fastq, params.raise_server)
     }
     else if (params.module == "sourmash_classification") {
         sourmash_classify(fastq_ch)
@@ -53,6 +53,13 @@ workflow run_module {
         kreport_ch = Channel.of([unique_id, "default", kreport])
         taxonomy_dir = file(params.taxonomy, type: "dir", checkIfExists: true)
         extract_all(fastq_ch, assignments_ch, kreport_ch, taxonomy_dir)
+    }
+     else if (params.module == "kraken_reclassification") {
+        assignments = file(params.kraken_assignments, type: "file", checkIfExists: true)
+        assignments_ch = Channel.of([unique_id, "default", assignments])
+        kreport = file(params.kraken_report, type: "file", checkIfExists: true)
+        kreport_ch = Channel.of([unique_id, "default", kreport])
+        reclassify(fastq_ch, assignments_ch, kreport_ch, params.raise_server)
     }
     else if (params.module == "classify_novel_viruses") {
         classify_virus_fastq(fastq_ch)


### PR DESCRIPTION
NB fixing small bug, don't test yet...

Changes include:
- Generating concatenated fastq by default when running module
- The `kraken_classification` module includes optional viral reclassification
- Additionally `kraken_reclassification` allows you to only reclassify

This has included pulling out the `reclassify` part of the `classify` workflow and calling it from `classify`.

Example commands:
Run basic kraken classification with default db
```
run main.nf --module kraken_classification --unique_id "test" --fastq test/test_data/barcode01/barcode01.fq.gz -profile docker,local
```
Run reclassification, passing in the assignments/report from the first classification
```
nextflow run main.nf --module kraken_reclassification --kraken_assignments output/test/classifications/PlusPF-8.kraken_assignments.tsv --kraken_report output/test/classifications/PlusPF-8.kraken_report.txt --unique_id "test" --fastq test/test_data/barcode01/barcode01.fq.gz -profile docker,local
```
Chain these steps together, extracting and passing in the viral and unclassified fraction to the second step. NB this is slightly different than running the above 2 steps as they pass the entire fastq to the second step.
```
nextflow run main.nf --module kraken_classification --unique_id "test" --fastq test/test_data/barcode01/barcode01.fq.gz --run_viral_reclassification -profile docker,local
```