### PR TITLE
add missing container for unpack_taxonomy process

### DIFF
--- a/modules/setup_taxonomy.nf
+++ b/modules/setup_taxonomy.nf
@@ -1,6 +1,7 @@
 process unpack_taxonomy {
     label "process_single"
     storeDir "${params.store_dir}"
+    container "${params.wf.container}:${params.wf.container_version}"
 
     input:
     path taxonomy


### PR DESCRIPTION
unpack_taxonomy is missing a container directive causing it to fail on k8 executors (climb)

amended to use the `params.wf.container` image